### PR TITLE
Ajout détection de collision rayon/triangles

### DIFF
--- a/src/alglin.hpp
+++ b/src/alglin.hpp
@@ -70,3 +70,46 @@ struct Mat3 {
         return m;
     }
 };
+
+inline float dot(const Vec3& a, const Vec3& b) {
+    return a.x*b.x + a.y*b.y + a.z*b.z;
+}
+
+inline Vec3 cross(const Vec3& a, const Vec3& b) {
+    return Vec3(
+        a.y*b.z - a.z*b.y,
+        a.z*b.x - a.x*b.z,
+        a.x*b.y - a.y*b.x
+    );
+}
+
+inline Vec3 normalize(const Vec3& v) {
+    float len = std::sqrt(dot(v, v));
+    if (len == 0.0f) return v;
+    return v * (1.0f / len);
+}
+
+// Ray/triangle intersection using Möller–Trumbore algorithm
+inline bool intersectRayTriangle(const Vec3& orig, const Vec3& dir,
+                                 const Vec3& v0, const Vec3& v1, const Vec3& v2,
+                                 float& t, Vec3& hitPoint) {
+    const float EPS = 1e-6f;
+    Vec3 edge1 = v1 - v0;
+    Vec3 edge2 = v2 - v0;
+    Vec3 h = cross(dir, edge2);
+    float a = dot(edge1, h);
+    if (std::fabs(a) < EPS) return false;
+    float f = 1.0f / a;
+    Vec3 s = orig - v0;
+    float u = f * dot(s, h);
+    if (u < 0.0f || u > 1.0f) return false;
+    Vec3 q = cross(s, edge1);
+    float v = f * dot(dir, q);
+    if (v < 0.0f || u + v > 1.0f) return false;
+    float tTmp = f * dot(edge2, q);
+    if (tTmp < 0.0f) return false;
+    t = tTmp;
+    hitPoint = orig + dir * t;
+    return true;
+}
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -177,12 +177,25 @@ int main() {
         float screenY = -((mouseY - HEIGHT / 2.0f) / (HEIGHT / 2.0f)  - offsetY) / scale;
         Vec3 base = unitX * screenX + unitY * screenY;
 
+        Vec3 rayOrigin = base;
+        Vec3 rayDir = unitZ; // vers l'avant de la scène
+        Vec3 nearestHit;
+        float nearestT = 1e9f;
+        bool hasHit = false;
+
         for (auto& p : Objxs) {
             for (auto& s : p.getSurfaces()) {
                 string tex = fs::path(s.texture).filename().string();
                 glBindTexture(GL_TEXTURE_2D, textureIDs[tex]);
                 const auto& pts = s.points;
                 for (size_t i = 0; i + 2 < pts.size(); i += 3) {
+                    Vec3 v0(pts[i].x, pts[i].y, pts[i].z);
+                    Vec3 v1(pts[i+1].x, pts[i+1].y, pts[i+1].z);
+                    Vec3 v2(pts[i+2].x, pts[i+2].y, pts[i+2].z);
+                    float tHit; Vec3 hp;
+                    if (intersectRayTriangle(rayOrigin, rayDir, v0, v1, v2, tHit, hp)) {
+                        if (tHit < nearestT) { nearestT = tHit; nearestHit = hp; hasHit = true; }
+                    }
                     float tri[15];
                     for (int j = 0; j < 3; ++j) {
                         tri[j*5+0] = pts[i+j].x;
@@ -194,13 +207,24 @@ int main() {
                     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(float), tri);
                     glEnableVertexAttribArray(0);
                     GLint texCoordLoc = glGetAttribLocation(program, "aTexCoord");
-                    glVertexAttribPointer(texCoordLoc, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float), tri + 3);
-                    glEnableVertexAttribArray(texCoordLoc);
-                    glDrawArrays(GL_TRIANGLES, 0, 3);
-                }
+                glVertexAttribPointer(texCoordLoc, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float), tri + 3);
+                glEnableVertexAttribArray(texCoordLoc);
+                glDrawArrays(GL_TRIANGLES, 0, 3);
             }
         }
-        
+        }
+
+        if (hasHit) {
+            float pt[5] = {nearestHit.x, nearestHit.y, nearestHit.z, 0.5f, 0.5f};
+            glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(float), pt);
+            glEnableVertexAttribArray(0);
+            GLint texCoordLoc = glGetAttribLocation(program, "aTexCoord");
+            glVertexAttribPointer(texCoordLoc, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float), pt + 3);
+            glEnableVertexAttribArray(texCoordLoc);
+            glPointSize(8.0f);
+            glDrawArrays(GL_POINTS, 0, 1);
+        }
+
                 // ligne entre z=0 et z=5
         Vec3 p0 = base;
         Vec3 p1 = base + unitZ * 5.0f;


### PR DESCRIPTION
## Summary
- ajout d’outils géométriques dans `alglin.hpp` (produit scalaire, produit vectoriel et test de collision rayons/triangles)
- utilisation du hit-test dans la boucle de rendu pour afficher le point d’impact le plus proche

## Testing
- `make` *(échec : `sdl2-config` introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68618d2f384883238920b097d29ec225